### PR TITLE
Add only_if argument to fasp_share_lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ The actual announcements are then sent to all subscribed providers by a backgrou
 fasp_share_lifecycle category: "account", uri_method: :my_canonical_uri, queue: "fasp_broadcasts"
 ```
 
+You can also add an `only_if` argument to point to a method that returns true if an item should be shared, allowing you to only share certain items:
+
+```ruby
+fasp_share_lifecycle category: "account", uri_method: :my_canonical_uri, only_if: :public?
+```
+
 Only new lifecycle events are currently sent. Whilst backfill requests can be made, they aren't serviced yet (see https://github.com/manyfold3d/fasp_client/issues/25).
 
 #### follow_recommendation

--- a/spec/dummy/app/models/account.rb
+++ b/spec/dummy/app/models/account.rb
@@ -1,9 +1,13 @@
 class Account < ApplicationRecord
   include FaspClient::DataSharing::Lifecycle
 
-  fasp_share_lifecycle category: "account", uri_method: :uri
+  fasp_share_lifecycle category: "account", uri_method: :uri, only_if: :announce?
 
   def uri
     "https://example.com/accounts/#{id}"
+  end
+
+  def announce?
+    true
   end
 end

--- a/spec/models/concerns/lifecycle_spec.rb
+++ b/spec/models/concerns/lifecycle_spec.rb
@@ -19,6 +19,12 @@ describe FaspClient::DataSharing::Lifecycle do
         event_type: "delete", category: "account", uri: "https://example.com/accounts/1"
       )
     end
+
+    it "doesn't emit event if only_if method returns false" do
+      account = Account.create
+      allow(account).to receive(:announce?).and_return(false)
+      expect { account.touch }.not_to have_enqueued_job(FaspClient::LifecycleAnnouncementJob)
+    end
   end
 
   context "when announcing content lifecycle" do


### PR DESCRIPTION
Allows limiting lifecycle sharing to a method in the client app.